### PR TITLE
Add startTLS support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,12 @@
   :url "https://github.com/puppetlabs/clj-ldap"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.unboundid/unboundid-ldapsdk "2.3.0"]]
-  :dev-dependencies [[jline "0.9.94"]
-                     [org.apache.directory.server/apacheds-all "1.5.5"]
-                     [fs "1.1.2"]
-                     [org.slf4j/slf4j-simple "1.5.6"]
-                     [lein-clojars "0.7.0"]]
+  :profiles {:dev {:dependencies [[jline "0.9.94"]
+                                  [org.apache.directory.server/apacheds-all "1.5.5"]
+                                  [fs "1.1.2"]
+                                  [org.slf4j/slf4j-simple "1.5.6"]]}}
   :aot [clj-ldap.client]
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"})
-

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject puppetlabs/clj-ldap "0.1.0-SNAPSHOT"
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.unboundid/unboundid-ldapsdk "2.3.0"]]
   :dev-dependencies [[jline "0.9.94"]
                      [org.apache.directory.server/apacheds-all "1.5.5"]

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -75,7 +75,7 @@
   "Adds the values contained in given response control to the given map"
   [m control]
   (condp instance? control
-    PreReadResponseControl 
+    PreReadResponseControl
     (update-in m [:pre-read] merge (entry-as-map (.getEntry control) false))
     PostReadResponseControl
     (update-in m [:post-read] merge (entry-as-map (.getEntry control) false))
@@ -252,8 +252,8 @@
   (if-let [n (.nextEntry source)]
     (cons n (lazy-seq (entry-seq source)))))
 
-;; Extended version of search-results function using a 
-;; SearchRequest that uses a SimplePagedResultsControl.  
+;; Extended version of search-results function using a
+;; SearchRequest that uses a SimplePagedResultsControl.
 ;; Allows us to read arbitrarily large result sets.
 ;; TODO make this lazy
 (defn- search-all-results
@@ -269,15 +269,15 @@
       (.setControls req (list (SimplePagedResultsControl. sizeLimit cookie)))
       (let [res (.search connection req)
             control (SimplePagedResultsControl/get res)
-            newres (->> (.getSearchEntries res) 
-                     (map entry-as-map) 
-                     (remove empty?) 
+            newres (->> (.getSearchEntries res)
+                     (map entry-as-map)
+                     (remove empty?)
                      (into results))]
         (if (and
               (not-nil? control)
               (> (.getValueLength (.getCookie control)) 0))
           (recur newres (.getCookie control))
-          (seq newres)))))) 
+          (seq newres))))))
 
 (defn- search-results
   "Returns a sequence of search results for the given search criteria."
@@ -352,7 +352,7 @@
                     JKS format file, optional, defaults to trusting all
                     certificates
    :connect-timeout The timeout for making connections (milliseconds),
-                    defaults to 1 minute   
+                    defaults to 1 minute
    :timeout         The timeout when waiting for a response from the server
                     (milliseconds), defaults to 5 minutes
    "
@@ -376,7 +376,7 @@ If an LDAP connection pool object is passed as the connection argument
 the bind attempt will have no side-effects, leaving the state of the
 underlying connections unchanged."
   [connection bind-dn password]
-  (try 
+  (try
     (let [bind-result (.bind connection bind-dn password)]
       (if (= ResultCode/SUCCESS (.getResultCode bind-result)) true false))
     (catch Exception _ false)))
@@ -439,7 +439,7 @@ returned either before or after the modifications have taken place."
    the password of the currently-authenticated user, or another user if their
    DN is provided and the caller has the required authorisation."
   ([connection new]
-    (let [request (PasswordModifyExtendedRequest. new)] 
+    (let [request (PasswordModifyExtendedRequest. new)]
       (.processExtendedOperation connection request)))
 
   ([connection old new]
@@ -453,9 +453,9 @@ returned either before or after the modifications have taken place."
 (defn modify-rdn
   "Modifies the RDN (Relative Distinguished Name) of an entry in the connected
   ldap server.
-  
+
   The new-rdn has the form cn=foo or ou=foo. Using just foo is not sufficient.
-  The delete-old-rdn boolean option indicates whether to delete the current 
+  The delete-old-rdn boolean option indicates whether to delete the current
   RDN value from the target entry."
   [connection dn new-rdn delete-old-rdn]
   (let [request (ModifyDNRequest. dn new-rdn delete-old-rdn)]

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -104,12 +104,18 @@
     (when timeout         (.setResponseTimeoutMillis opt timeout))
     opt))
 
+(defn- create-trust-manager
+  "If the trust-store is truthy, returns a TrustStoreTrustManager created with
+  it; otherwise, returns a TrustAllTrustManager."
+  [trust-store]
+  (if trust-store
+    (TrustStoreTrustManager. trust-store)
+    (TrustAllTrustManager.)))
+
 (defn- create-ssl-factory
   "Returns a SSLSocketFactory object"
   [{:keys [trust-store]}]
-  (let [trust-manager (if trust-store
-                        (TrustStoreTrustManager. trust-store)
-                        (TrustAllTrustManager.))
+  (let [trust-manager (create-trust-manager trust-store)
         ssl-util (SSLUtil. trust-manager)]
     (.createSSLSocketFactory ssl-util)))
 

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -63,6 +63,8 @@
    (ldap/connect {:host (str "localhost:" port)})
    (ldap/connect {:ssl? true
                   :host {:port ssl-port}})
+   (ldap/connect {:start-tls? true
+                  :host {:port port}})
    (ldap/connect {:host {:port port}
                   :connect-timeout 1000
                   :timeout 5000})

--- a/test/clj_ldap/test/server.clj
+++ b/test/clj_ldap/test/server.clj
@@ -7,6 +7,8 @@
             DirectoryService])
   (:import [org.apache.directory.server.ldap
             LdapServer])
+  (:import [org.apache.directory.server.ldap.handlers.extended
+            StartTlsHandler])
   (:import [org.apache.directory.server.protocol.shared.transport
             TcpTransport])
   (:import [java.util HashSet])
@@ -46,6 +48,7 @@
         ldap-server (doto (LdapServer.)
                       (.setDirectoryService directory-service)
                       (.setAllowAnonymousAccess true)
+                      (.addExtendedOperationHandler (StartTlsHandler.))
                       (.setTransports
                        (into-array [ldap-transport ssl-transport])))]
     (-> (add-partition! directory-service


### PR DESCRIPTION
Change the options to `create-connection` to look for a `tls?` key, in
addition to `ssl?`. If `tls?` is truthy, then have the connection
perform the startTLS invocation after it's created. If both `tls?` and
`ssl?` are truthy, throw an IllegalArgumentException, as the two are
mutually exclusive.

Add a test to ensure that we can connect to the server and perform the
startTLS invocation without errors (this is not a strong test that
startTLS works, but it's as strong as the SSL tests, and a truly strong
test would be much more work).
