### PR TITLE
support setFollowReferrals on LDAPConnectionOptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/clj-ldap "0.1.2-SNAPSHOT"
+(defproject puppetlabs/clj-ldap "0.1.4"
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
   :dependencies [[org.clojure/clojure "1.6.0"]

--- a/src/clj_ldap/client.clj
+++ b/src/clj_ldap/client.clj
@@ -99,10 +99,11 @@
 
 (defn- connection-options
   "Returns a LDAPConnectionOptions object"
-  [{:keys [connect-timeout timeout]}]
+  [{:keys [connect-timeout timeout follow-referrals?]}]
   (let [opt (LDAPConnectionOptions.)]
     (when connect-timeout (.setConnectTimeoutMillis opt connect-timeout))
     (when timeout         (.setResponseTimeoutMillis opt timeout))
+    (when (some? follow-referrals?) (.setFollowReferrals opt follow-referrals?))
     opt))
 
 (defn- create-trust-manager
@@ -373,6 +374,7 @@
    :bind-dn         The DN to bind as, optional
    :password        The password to bind with, optional
    :num-connections The number of connections in the pool, defaults to 1
+   :follow-referrals? Boolean, whether or not to follow Active Directory referrals
    :ssl?            Boolean, connect over SSL (ldaps), defaults to false
    :trust-store     Only trust SSL certificates that are in this
                     JKS format file, optional, defaults to trusting all


### PR DESCRIPTION
This has no functional change besides passing an option through to the underlying UnboundID LDAP Connection Options instance when creating a connection.
