### PR TITLE
(PE-12046) update unboundid-ldapsdk to 3.1.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,12 @@
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.unboundid/unboundid-ldapsdk "2.3.8"]]
+                 [com.unboundid/unboundid-ldapsdk "3.1.1"]]
   :profiles {:dev {:dependencies [[jline "0.9.94"]
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]
                                   [org.slf4j/slf4j-simple "1.5.6"]]}}
-  :deploy-repositories [["local-test" "file:///home/dlp/lein-test"]]
+  :deploy-repositories [["local-test"]]
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,11 @@
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]
                                   [org.slf4j/slf4j-simple "1.5.6"]]}}
-  :deploy-repositories [["local-test"]]
+
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_jenkins_username
+                                     :password :env/clojars_jenkins_password
+                                     :sign-releases false}]]
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo


### PR DESCRIPTION
Reading the release notes for unboundid's ldap-sdk, there have been several fixes from 2.3.8 through 3.1.1 around connection failures, which may be related to test failures we have seen in our internal tests.
