### PR TITLE
(maint) Allow short RSA keys during testing

### DIFF
--- a/dev-resources/java.security
+++ b/dev-resources/java.security
@@ -1,0 +1,4 @@
+# The embedded LDAP server may use RSA keys with short moduli during testing;
+# this security file disables short key checking during testing so that we
+# don't have to roll our own TLS key generation.
+jdk.certpath.disabledAlgorithms=

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,9 @@
   :profiles {:dev {:dependencies [[jline "0.9.94"]
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]
-                                  [org.slf4j/slf4j-simple "1.5.6"]]}}
+                                  [org.slf4j/slf4j-simple "1.5.6"]]
+                   :jvm-opts ["-Djava.security.properties=./dev-resources/java.security"]}}
+
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username


### PR DESCRIPTION
Newer versions of Debian Jessie have tighter restrictions on what RSA
key sizes can be allowed, while the apacheds default key generator might
use short key sizes. This commit adds a java.security file that's
enabled during development and testing to simplify use of the default
embedded LDAP server.