### PR TITLE
(maint) update unboundid and clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 0.2.0
+  * update clojure dependency to 1.8.0
+  * update unboundid to 4.0.7

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject puppetlabs/clj-ldap "0.1.7-SNAPSHOT"
+(defproject puppetlabs/clj-ldap "0.2.0-SNAPSHOT"
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.unboundid/unboundid-ldapsdk "3.1.1"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [com.unboundid/unboundid-ldapsdk "4.0.7"]]
   :profiles {:dev {:dependencies [[jline "0.9.94"]
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]


### PR DESCRIPTION
The versions of clojure and unboundid were woefully out of date.
This updates them to more recent versions, and resets the
version number to 0.2.0 for the next release.

A changelog was added.