### PR TITLE
(PE-26836) fix base64 encoded attribute handling, update unbound lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.2.1
+  * don't encode items that have been base-64 decoded
+  * ipdate unboundid to 4.0.11
 ### 0.2.0
   * update clojure dependency to 1.8.0
   * update unboundid to 4.0.7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/products/ldap-sdk/) and allows clojure programs to talk to ldap servers. This library is available on [clojars.org](http://clojars.org/search?q=clj-ldap)
 
-     :dependencies [[org.clojars.pntblnk/clj-ldap "0.0.9"]]
+     :dependencies [[puppetlabs/clj-ldap "0.2.1"]]
 
 # Example
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.unboundid/unboundid-ldapsdk "4.0.7"]]
+                 [com.unboundid/unboundid-ldapsdk "4.0.11"]]
   :profiles {:dev {:dependencies [[jline "0.9.94"]
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]

--- a/test/clj_ldap/test/client.clj
+++ b/test/clj_ldap/test/client.clj
@@ -25,9 +25,9 @@
 
 ;; People to test with
 (def person-a*
-     {:dn (format dn* "testa")
+     {:dn (format dn* "testaü")
       :object {:objectClass object-class*
-               :cn "testa"
+               :cn "testaü"
                :sn "a"
                :description "description a"
                :telephoneNumber "000000001"
@@ -73,8 +73,8 @@
    (ldap/connect {:host [(str "localhost:" ssl-port)
                          {:port ssl-port}]
                   :ssl? true
-                  :num-connections 5})  
-   ])
+                  :num-connections 5})])
+
 
 
 (defn- test-server
@@ -186,16 +186,16 @@
 (deftest test-search
   (is (= (set (map :cn
                    (ldap/search *conn* base* {:attributes [:cn]})))
-         (set [nil "testa" "testb" "Saul Hazledine"])))
+         (set [nil "testaü" "testb" "Saul Hazledine"])))
   (is (= (set (map :cn
                    (ldap/search *conn* base*
                                 {:attributes [:cn] :filter "cn=test*"})))
-         (set ["testa" "testb"])))
+         (set ["testaü" "testb"])))
   (binding [*side-effects* #{}]
     (ldap/search! *conn* base* {:attributes [:cn :sn] :filter "cn=test*"}
                   (fn [x]
                     (set! *side-effects*
                           (conj *side-effects* (dissoc x :dn)))))
     (is (= *side-effects*
-           (set [{:cn "testa" :sn "a"}
+           (set [{:cn "testaü" :sn "a"}
                  {:cn "testb" :sn "b"}])))))


### PR DESCRIPTION
This fixes an issue where items that were base-64 encoded by the LDAP
server and were correctly decoded were reencoded to base64 again.

This fixes an issue where user names have extended characters, for example.
The tests were updated to reflect the new case.

unboundid is also updated to the latest version.

Finally, some indentation issues were fixed, unused code removed, and
unused requires removed.