### PR TITLE
(PE-28676) allow validating SSL connections via TrustManager array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+### 0.3.0
+  * add trust-managers as an accepted option to connect
+  * update clojure dependency to 1.10.1
+  * update unboundid to 5.0.1
 ### 0.2.1
   * don't encode items that have been base-64 decoded
-  * ipdate unboundid to 4.0.11
+  * update unboundid to 4.0.11
 ### 0.2.0
   * update clojure dependency to 1.8.0
   * update unboundid to 4.0.7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 clj-ldap is a thin layer on the [unboundid sdk](http://www.unboundid.com/products/ldap-sdk/) and allows clojure programs to talk to ldap servers. This library is available on [clojars.org](http://clojars.org/search?q=clj-ldap)
 
-     :dependencies [[puppetlabs/clj-ldap "0.2.1"]]
+     :dependencies [[puppetlabs/clj-ldap "0.3.0"]]
 
 # Example
 
@@ -46,6 +46,8 @@ Options is a map with the following entries:
     :trust-store     Only trust SSL certificates that are in this
                      JKS format file, optional, defaults to trusting all
                      certificates
+    :trust-managers  An optional TrustManager array to be used in place of
+                     a temporary keystore to create an SSLSocketFactory.
     :verify-host?    Verifies the hostname of the specified certificate,
                      false by default.
     :wildcard-host?  Allows wildcard in certificate hostname verification,
@@ -133,7 +135,7 @@ a map in the form:
       :post-read
         #{:attribute-c :attribute-d}}
 
-Where :add adds an attribute value, :delete deletes an attribute value and :replace replaces the set of values for the attribute with the ones specified. The entries :pre-read and :post-read specify attributes that have be read and returned either before or after the modifications have taken place. 
+Where :add adds an attribute value, :delete deletes an attribute value and :replace replaces the set of values for the attribute with the ones specified. The entries :pre-read and :post-read specify attributes that have be read and returned either before or after the modifications have taken place.
 
 All the keys in the map are optional e.g:
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,10 @@
-(defproject puppetlabs/clj-ldap "0.2.2-SNAPSHOT"
+(defproject puppetlabs/clj-ldap "0.3.0-SNAPSHOT"
   :description "Clojure ldap client (Puppet Labs's fork)."
   :url "https://github.com/puppetlabs/clj-ldap"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.unboundid/unboundid-ldapsdk "4.0.11"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [com.unboundid/unboundid-ldapsdk "5.0.1"]]
+  :source-paths ["src/clojure"]
+  :java-source-paths ["src/java"]
   :profiles {:dev {:dependencies [[jline "0.9.94"]
                                   [org.apache.directory.server/apacheds-all "1.5.5"]
                                   [fs "1.1.2"]

--- a/src/clojure/clj_ldap/client.clj
+++ b/src/clojure/clj_ldap/client.clj
@@ -33,8 +33,8 @@
   (:import [com.unboundid.util.ssl
             SSLUtil
             TrustAllTrustManager
-            TrustStoreTrustManager
-            HostNameSSLSocketVerifier]))
+            HostNameSSLSocketVerifier])
+  (:import [com.puppetlabs.ldap Utils]))
 
 ;;======== Helper functions ====================================================
 
@@ -99,19 +99,22 @@
     (when (true? verify-host?) (.setSSLSocketVerifier opt (HostNameSSLSocketVerifier. (true? wildcard-host?))))
     opt))
 
-(defn- create-trust-manager
-  "If the trust-store is truthy, returns a TrustStoreTrustManager created with
-  it; otherwise, returns a TrustAllTrustManager."
-  [trust-store]
-  (if trust-store
-    (TrustStoreTrustManager. trust-store)
-    (TrustAllTrustManager.)))
+(defn- create-ssl-util
+  "If the trust-manager is truthy, returns a SSLUtil created with
+  it; otherwise, if trust-store is truthy, returns a SSLUtil created with
+  it. If both are falsy, returns a SSLUtil created with a TrustAllTrustManager."
+  [trust-managers trust-store]
+  (if trust-managers
+    (Utils/trustManagersToSSLUtil trust-managers)
+    (if trust-store
+      (Utils/trustStoreToSSLUtil trust-store)
+      (Utils/trustManagerToSSLUtil
+        (TrustAllTrustManager.)))))
 
 (defn- create-ssl-factory
   "Returns a SSLSocketFactory object"
-  [{:keys [trust-store]}]
-  (let [trust-manager (create-trust-manager trust-store)
-        ssl-util (SSLUtil. trust-manager)]
+  [{:keys [trust-managers trust-store]}]
+  (let [ssl-util (create-ssl-util trust-managers trust-store)]
     (.createSSLSocketFactory ssl-util)))
 
 (defn- host-as-map
@@ -355,6 +358,8 @@
    :trust-store     Only trust SSL certificates that are in this
                     JKS format file, optional, defaults to trusting all
                     certificates
+   :trust-managers  An optional TrustManager array to be used in place of
+                    a temporary keystore to create an SSLSocketFactory.
    :verify-host?    Verifies the hostname of the specified certificate,
                     false by default.
    :wildcard-host?  Allows wildcard in certificate hostname verification,

--- a/src/java/com/puppetlabs/ldap/Utils.java
+++ b/src/java/com/puppetlabs/ldap/Utils.java
@@ -1,0 +1,21 @@
+package com.puppetlabs.ldap;
+
+import com.unboundid.util.ssl.SSLUtil;
+import com.unboundid.util.ssl.TrustStoreTrustManager;
+
+import javax.net.ssl.TrustManager;
+
+public class Utils {
+
+    public static SSLUtil trustManagersToSSLUtil(final TrustManager[] tm) {
+        return new SSLUtil(tm);
+    }
+
+    public static SSLUtil trustStoreToSSLUtil(String ts) {
+        return new SSLUtil(new TrustStoreTrustManager(ts));
+    }
+
+    public static SSLUtil trustManagerToSSLUtil(final TrustManager tm) {
+      return new SSLUtil(tm);
+    }
+}


### PR DESCRIPTION
As part of the changes to allow FIPS users to use ldap successfully, this commit extends the options object passed to the connect function to take a trust-managers key, to be used in place of a trust-store for creating the SSLSocketFactory. It also updated unbound to the latest version (5.0.1).