### PR TITLE
Add case to client/create-modification to support directly supplying bytes

### DIFF
--- a/src/clojure/clj_ldap/client.clj
+++ b/src/clojure/clj_ldap/client.clj
@@ -215,6 +215,7 @@
   [modify-op attribute values]
   (cond
     (coll? values)    (Modification. modify-op attribute (into-array values))
+    (bytes? values)   (Modification. modify-op attribute values)
     (= :all values)   (Modification. modify-op attribute)
     :else             (Modification. modify-op attribute (str values))))
 


### PR DESCRIPTION
For some operations, such as setting unicodePwd for an Active Directory entry,
the simplest way to provide the value of an attribute is as a byte array due to
encoding issues. As-is, when `values` is a byte array, it matches `:else` and
is processed with `str`, which is substantively incorrect.

The current behavior is particularly confusing because the underlying LDAP SDK
supports providing a byte array out of the box, and because the value that will
be written is not even an incorrectly-encoded version of `values`; it will be a
string of the form "[B@\<reference\>".